### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.2](https://github.com/adrianiy/release-notes-generator/compare/v1.1.1...v1.1.2) (2021-10-17)
+
+
+### Bug Fixes
+
+* fix release files to publish lib/ ([04c0dbe](https://github.com/adrianiy/release-notes-generator/commit/04c0dbec6b119c6defafc43c9fb675e35130d776))
+
 # [1.1.0](https://github.com/adrianiy/release-notes-generator/compare/v1.0.0...v1.1.0) (2021-10-17)
 
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,7 @@
 # RELEASE NOTES
 
+
+
 ## :rocket: Release 1.1.0 
 ###### 2021-10-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adrian.insua/release-notes-generator",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "Repository parser to generate release notes using your PRs",
     "main": "lib/index.js",
     "publishConfig": {


### PR DESCRIPTION
We need graphql-import-node to be installed in production

So we moved it from `devDependencies` to `dependencies`


