### PR TITLE
Move section decoration to config

### DIFF
--- a/.releasenotesrc.yml
+++ b/.releasenotesrc.yml
@@ -6,5 +6,5 @@ assets:
   - CHANGELOG.md
   - package.json
 decoration:
-  type/feature: ':zap: '
-  type/bug: ':bug: '
+  type/feature: '## :zap: '
+  type/bug: '## :bug: '

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -65,12 +65,12 @@ const defaultConfiguration: Configuration = {
     webhooks: {},
     title: 'RELEASE NOTES',
     decoration: {
-        enhancement: ':zap: ',
-        bug: ':bug: ',
-        refactor: ':abacus: ',
-        release: ':rocket: ',
-        style: ':nailcare: ',
-        documentation: ':book: ',
+        enhancement: '## :zap: ',
+        bug: '## :bug: ',
+        refactor: '## :abacus: ',
+        release: '# :rocket: ',
+        style: '## :nailcare: ',
+        documentation: '## :book: ',
     },
 };
 

--- a/src/generator/github.ts
+++ b/src/generator/github.ts
@@ -21,9 +21,9 @@ export class GithubGenerator extends Generator {
 
     private _composeText = (pr: PullRequest) => {
         const decoration = this._configuration.decoration!;
-        const icon = pr.labels.find((label: string) => decoration[label]) || '';
+        const decorationMatch = pr.labels.find((label: string) => decoration[label]) || '';
         const date = format(new Date(pr.createdAt), 'yyyy-MM-dd');
 
-        return `## ${decoration[icon] || ''}${pr.title} \n###### ${date}\n\n${pr.body}\n`;
+        return `${decoration[decorationMatch] || ''}${pr.title} \n###### ${date}\n\n${pr.body}\n`;
     };
 }


### PR DESCRIPTION
### Changes
<!-- Specify changes you've done in your PR, be as specific as you can! :) -->

Release sections have not the required relevance as they are decorated with `##` as any other issue.

To solve this we move section decorators `#` to configuration object, this allow users to configure as many `#` as they want.


