### PR TITLE
Stop gen pipe if no PRs found

### DIFF
--- a/release-notes/RELEASE-NOTES-v1.8.0.md
+++ b/release-notes/RELEASE-NOTES-v1.8.0.md
@@ -1,2 +1,17 @@
 # RELEASE NOTES
 
+# :rocket: Release 1.8.0 
+###### 2021-10-30
+
+---
+
+## :zap: Split release notes by release number 
+###### 2021-10-30
+
+### Changes
+<!-- Specify changes you've done in your PR, be as specific as you can! :) -->
+
+Now we are splitting release notes by release number instead of timestamp, this help us avoid unnecessary files creation.
+
+To improve experience we've changed default value of `useLast` to `2` so we get release-notes from the second latest release to the latest one, and we use latest release number in file name.
+

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -27,11 +27,14 @@ export abstract class Generator {
 
     async generateReleaseNotes(): Promise<void> {
         const list = await this._getPullRequestList();
-        const markdown = this._parsePullRequests(list);
 
-        await this._labelPullRequests(list);
+        if (list.length) {
+            const markdown = this._parsePullRequests(list);
 
-        this._storeMarkdown(markdown);
+            await this._labelPullRequests(list);
+
+            this._storeMarkdown(markdown);
+        }
     }
 
     async publishReleaseNotes(): Promise<void> {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -25,7 +25,7 @@ export class PluginLoader {
     }
 
     async executePlugins(): Promise<void> {
-        if (this._configuration.webhooks) {
+        if (Object.keys(this._configuration.webhooks || {}).length) {
             let willExecute = true;
             if (this._interactive) {
                 const { response } = await inquirer.prompt([


### PR DESCRIPTION
### Changes
<!-- Specify changes you've done in your PR, be as specific as you can! :) -->

If no pull requests are found in generation process we will not generate release notes markdown.

This way we are not replacing old **release-notes** with an empty string

### Issues
<!-- Link related issue after close using # notation. `Close #123`-->

Close #83 


