### PR TITLE
Customize labels

### DIFF
--- a/.releasenotesrc.yml
+++ b/.releasenotesrc.yml
@@ -1,9 +1,14 @@
 message: "chore: update RELEASE-NOTES [skip ci]"
 split: true
 out: '.'
-ignored-labels:
-  - in-release-note
-  - released
+labels:
+  include:
+    - release-note/use
+  ignore:
+    - released
+    - release-note/published
+  end:
+    - release-note/published
 assets:
   - CHANGELOG.md
   - package.json

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A **complete markdown** file will be created using your pull request description
 <details>
 	<summary>How Release Notes are done</summary>
 
-1. Parse every PR **since last RELEASE**.
+1. Parse every PR **in latest RELEASE**.
 	
 2. **Filter** Pull Requests by label.
 	
@@ -52,9 +52,8 @@ A **complete markdown** file will be created using your pull request description
   - [out](/src/configuration#out)
   - [split](/src/configuration#split)
   - [filter](/src/configuration#filter)
-  - [useLast](/src/configuration#use-last)
+  - [snapshot](/src/configuration#snapshot)
   - [labels](/src/configuration#labels)
-  - [ignoredLabels](/src/configuration#ignored-labels)
   - [title](/src/configuration#title)
   - [decoration](/src/configuration#decoration)
   - [publish](/src/configuration#publish)

--- a/src/commander/options.ts
+++ b/src/commander/options.ts
@@ -28,10 +28,10 @@ export const repoOptions: Record<string, Options> = {
         type: 'string',
         description: 'Start date in pull request filter query',
     },
-    use: {
-        alias: ['u', 'useLast'],
-        type: 'number',
-        description: 'Uses last n releases',
+    snapshot: {
+        alias: ['sn', 'snapshot'],
+        type: 'boolean',
+        description: 'Generates snapshot release notes',
     },
     message: {
         alias: 'm',

--- a/src/configuration/README.md
+++ b/src/configuration/README.md
@@ -6,9 +6,8 @@
   - [out](#out)
   - [split](#split)
   - [filter](#filter)
-  - [useLast](#use-last)
+  - [snapshot](#snapshot)
   - [labels](#labels)
-  - [ignoredLabels](#ignored-labels)
   - [title](#title)
   - [decoration](#decoration)
   - [publish](#publish)
@@ -37,9 +36,8 @@ We support `.yml` and `.json` formats with these options:
 | [out](#out) | `'.'` | Base path where `RELEASE-NOTES` will be generated |
 | [split](#split) | `false` | If `true` one file will be generated per iteration, and will be stored under a `release_notes` folder in `out` directory |
 | [filter](#filter) | `is:closed` | Filter applied on pull request query |
-| [useLast](#use-last) | 2 | Gets data from release `n` to release 0 |
+| [snapshot](#snapshot) | `false` | Generates snapshot release notes using Pull Request since latest release |
 | [labels](#labels) | `[ 'release-note' ]` | Only PRs with these labels will be used in generation process |
-| [ignoredLabels](#ignored-labels) | `[ 'in-release-note' ]` | PRs with these labels will be ignored |
 | [title](#title) | `RELEASE NOTES` | Title used in output markdown |
 | [decoration](#decoration) | [Decoration object](#decoration-object) | Icon decoration for each issue type |
 | [publish](#publish) | `false` | If `true` the output file will be commited to repo |
@@ -117,54 +115,33 @@ Default value looks for **closed** Pull Requests.
 filter: "is:open" # looks for open PRs
 ```
 
-### USE LAST
-##### Default value `2`
+### SNAPSHOT
+##### Default value `false`
 
-Gets data from release `n` to release 0.
-
-Value 2 means that we are getting PRs included in latest release.
-
-<details>
-  <summary>Example</summary>
-
-With latest releases:
-
-  1. 1.1.0
-  2. 1.0.0
-  3. 0.1.0
-
-- `useLast` with value 0 or 1 is used to get Release notes for unpublished version. We get all pull requests since version `1.1.0`.
-
-- `useLast` with value 2 means that we are getting all Pull Request from version `1.0.0` to `1.1.0`, creating the release notes for version `1.1.0`.
-
-- `useLast` with value 3 means taht we are getting all Pull Reqeust since `0.1.0`, creating the release notes for version `1.1.0`.
-
-</details>
+Generates snapshot release notes using Pull Request since latest release.
 
 ```yml
-useLast: 0 # RELEASE-NOTES for unpublished release
+snapshot: true # RELEASE-NOTES for unpublished release
 ```
 
 ### LABELS
-##### Default value `['release-note']`
+##### Default value [Label object](#label-object)
 
-Only PRs with these labels will be used in generation process.
+Configuration object to set wich labels will be **included**, **ignored** and used to **tag parsed** Pull Requests
+
+- include: Only Pull Requests with these labels will be included in release notes.
+- ignore: Pull Requests with these label will be ignored.
+- end: Once release notes are generated, Pull Requests will be tagged with these labels.
+
+#### Label object
+
+Default labels configuration.
 
 ```yml
 labels:
-  - release-note
-  - release-note-demo
-```
-
-### IGNORED LABELS
-##### Default value `[ 'in-release-note' ]`
-
-PRs with these labels will be ignored.
-
-```yml
-ignoredLabels:
-  - in-release-note
-  - in-release-note-demo
+  include: release-note
+  ignore: in-release-note
+  end: in-release-note
 ```
 
 ---

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -24,7 +24,7 @@ export interface Notification {
 export interface Labels {
     // Only PRs with this labels will be included in MD
     include?: string[];
-    // PRs with these labels will be ignores
+    // PRs with these labels will be ignored
     ignore?: string[];
     // Once RELEASE NOTES are generated PRs will be tagged with this labels
     end?: string[];
@@ -43,14 +43,12 @@ export interface Configuration {
     suffix?: string;
     // Only PRs with this labels will be included in MD
     labels?: Labels;
-    // PRs with these labels will be ignores
-    ignoredLabels?: string[];
     // PR query filter
     filter?: string;
     // Start date in pull request filter query
     since?: string;
-    // Use last n releases
-    useLast?: number;
+    // Generates snapshot release notes (from latest release)
+    snapshot?: boolean;
     // Split Release-Notes on file per Relase
     // This option will create a folder in `out` dir.
     split?: boolean;
@@ -82,7 +80,7 @@ const defaultConfiguration: Configuration = {
         end: ['in-release-note'],
     },
     publish: false,
-    useLast: 2,
+    snapshot: false,
     message: 'chore: update RELEASE-NOTES',
     branch: 'main',
     filter: 'is:closed',

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -21,6 +21,15 @@ export interface Notification {
     style: Customization;
 }
 
+export interface Labels {
+    // Only PRs with this labels will be included in MD
+    include?: string[];
+    // PRs with these labels will be ignores
+    ignore?: string[];
+    // Once RELEASE NOTES are generated PRs will be tagged with this labels
+    end?: string[];
+}
+
 export interface Configuration {
     // GITHUB authorization token
     token?: string;
@@ -33,7 +42,7 @@ export interface Configuration {
     // File sufix for splitted content
     suffix?: string;
     // Only PRs with this labels will be included in MD
-    labels?: string[];
+    labels?: Labels;
     // PRs with these labels will be ignores
     ignoredLabels?: string[];
     // PR query filter
@@ -67,8 +76,11 @@ const defaultConfiguration: Configuration = {
     token: 'GITHUB_TOKEN',
     out: '.',
     name: 'RELEASE-NOTES',
-    labels: ['release-note'],
-    ignoredLabels: ['in-release-note'],
+    labels: {
+        include: ['release-note'],
+        ignore: ['in-release-note'],
+        end: ['in-release-note'],
+    },
     publish: false,
     useLast: 2,
     message: 'chore: update RELEASE-NOTES',

--- a/src/connector/github.ts
+++ b/src/connector/github.ts
@@ -88,7 +88,7 @@ export class GitHubConnector extends Connector {
             owner: this._owner,
             repo: this._repo,
             issue_number: pullRequest.number,
-            labels: ['in-release-note'],
+            labels: this._configuration.labels?.end,
         });
     };
 
@@ -136,10 +136,10 @@ export class GitHubConnector extends Connector {
     }
 
     private _getLabelFilter(): string {
-        const { labels, ignoredLabels } = this._configuration;
+        const { labels: { include, ignore } = {} } = this._configuration;
 
-        const labelFilter = labels?.map((value: string) => `label:${value}`).join(' ') || '';
-        const ignoredLabelsFilter = ignoredLabels?.map((value: string) => `-label:${value}`).join(' ') || '';
+        const labelFilter = include?.map((value: string) => `label:${value}`).join(' ') || '';
+        const ignoredLabelsFilter = ignore?.map((value: string) => `-label:${value}`).join(' ') || '';
 
         return `${labelFilter} ${ignoredLabelsFilter}`;
     }

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -71,7 +71,7 @@ export abstract class Generator {
 
         const latestRelease: Release[] = await this._connector.getLatestRelease();
         const pullRequestsList: PullRequest[] = await this._connector.getPullRequests(latestRelease?.[0]?.createdAt);
-        this._configuration.suffix = latestRelease.slice(-1)[0].tagName;
+        this._configuration.suffix = this._configuration.useLast! > 1 ? latestRelease.slice(-1)[0].tagName : `${Date.now()}`;
         this._setFilePath();
 
         this._verbose && logger.info(`We've found ${pullRequestsList.length} pull requests to parse!`);


### PR DESCRIPTION
### Changes
<!-- Specify changes you've done in your PR, be as specific as you can! :) -->

Label management has improved using a configuration object

```yml
labels:
  include:
    - release-note/use
  ignore:
    - released
    - release-note/published
  end:
    - release-note/published
```

#### ⚠️ `useLast` attribute is deprecated.

By default **RNG** will include all Pull Request **in** latest published release
If you set `snapshot: true` all Pull Request **since** latest release will be used. 

### Issues
<!-- Link related issue after close using # notation. `Close #123`-->

Close #85 


