### PR TITLE
Order release note issue types

### DIFF
--- a/.releasenotesrc.yml
+++ b/.releasenotesrc.yml
@@ -15,3 +15,7 @@ assets:
 decoration:
   type/feature: '## :sparkles: '
   type/bug: '## :bug: '
+order:
+  - release
+  - type/feature 
+  - type/bug 

--- a/src/configuration/README.md
+++ b/src/configuration/README.md
@@ -11,6 +11,7 @@
   - [ignoreTag](#ignore-tag)
   - [title](#title)
   - [decoration](#decoration)
+  - [order](#order)
   - [preview](#preview)
   - [publish](#publish)
   - [branch](#branch)
@@ -43,6 +44,7 @@ We support `.yml` and `.json` formats with these options:
 | [ignoreTag](#ignore-tag) | `<!--release-notes-ignore-->` | Text inside this comment tag will be ignored in RELEASE NOTES |
 | [title](#title) | `RELEASE NOTES` | Title used in output markdown |
 | [decoration](#decoration) | [Decoration object](#decoration-object) | Icon decoration for each issue type |
+| [order](#order) | `['release', 'refactor', 'enhancement', 'bug', 'style', 'documentation']` | Order of issues in release notes |
 | [preview](#preview) | [Preview object](#preview-object) | Customize preview comment |
 | [publish](#publish) | `false` | If `true` the output file will be commited to repo |
 | [branch](#branch) | `main` | Branch where output will be uploaded |
@@ -208,6 +210,22 @@ Markdown for a pr tagged with `enhancement` label:
 
 ```markdown
 ## :zap: Issue title
+```
+
+### ORDER 
+##### Default value `['release', 'refactor', 'enhancement', 'bug', 'style', 'documentation']`
+
+Customize how your issues will be sort in release notes, as usually you'll need to group issues of one kind all together, and 
+give some preference of ones among others, i.e enhancement > bug
+
+```yml
+order:
+    - release 
+    - refactor
+    - enhancement 
+    - bug 
+    - style 
+    - documentation 
 ```
 
 ---

--- a/src/configuration/configuration.ts
+++ b/src/configuration/configuration.ts
@@ -74,6 +74,8 @@ export interface Configuration {
     title?: string;
     // Notes decoration according to type
     decoration?: Record<string, string>;
+    // Order of issue types in release notes 
+    order?: string[];
     // Webhooks lis
     webhooks?: Record<string, Webhook>;
     // Notification configuration
@@ -110,6 +112,14 @@ const defaultConfiguration: Configuration = {
         style: '## :nailcare: ',
         documentation: '## :book: ',
     },
+    order: [
+        'release',
+        'refactor',
+        'enhancement',
+        'bug',
+        'style',
+        'documentation'
+    ],
     notification: {
         style: {
             h1: { 'font-size': '3rem', 'margin-top': '2rem' },

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -92,6 +92,18 @@ export abstract class Generator {
         return pullRequestsList;
     }
 
+    protected _sortPullRequestByType(pullRequest: PullRequest[]): PullRequest[] {
+        if (this._configuration.order) {
+            return this._configuration.order.reduce((acc: PullRequest[], currType: string) => {
+                const group = pullRequest.filter(issue => issue.labels.includes(currType) && !acc.includes(issue));
+                
+                return acc.concat(group);
+            }, []);
+        }
+
+        return pullRequest;
+    }
+
     protected async _labelPullRequests(pullRequests: PullRequest[]): Promise<void> {
         const willPublish = !this._configuration.snapshot && (!this._interactive || (await confirmPullRequestLabeling()));
 

--- a/src/generator/github.ts
+++ b/src/generator/github.ts
@@ -11,7 +11,7 @@ export class GithubGenerator extends Generator {
 
     protected _parsePullRequests(pullRequests: PullRequest[]): string {
         const oldFile = this._configuration.split ? '' : this._loadMarkdown();
-        const notes = pullRequests.map(this._composeText);
+        const notes = this._sortPullRequestByType(pullRequests).map(this._composeText);
         const title = this._configuration.title?.length ? `# ${this._configuration.title}\n` : '';
         const markdown = [title, ...notes, oldFile].join('\n');
 


### PR DESCRIPTION
### Changes
<!-- Specify changes you've done in your PR, be as specific as you can! :) -->

You can now group & order issues in release notes using `order` configuration parameter

<!--release-notes-ignore-->
### Issues
<!-- Link related issue after close using # notation. `Close #123`-->

Close #105 
<!--release-notes-ignore-->


